### PR TITLE
Changed <2B or 7B> to <2b or 7b> in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can find the model checkpoints on Kaggle
 Note that you can choose between the 2B, 7B, 7B int8 quantized variants.
 
 ```
-VARIANT=<2B or 7B>
+VARIANT=<2b or 7b>
 CKPT_PATH=<Insert ckpt path here>
 ```
 


### PR DESCRIPTION
The README suggests to set variant of the model to either 2B or 7B but the docker actually gets "2b" or "7b" as an input (see also line 68 of run.py).
