### PR TITLE
Add instructions to download from Hugging Face Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ This is the official PyTorch implementation of Gemma models. We provide model an
 You can find the model checkpoints on Kaggle
 [here](https://www.kaggle.com/models/google/gemma/frameworks/pyTorch).
 
+Alternatively, you can find the model checkpoints on the Hugging Face Hub [here](https://huggingface.co/models?other=gemma_torch). To download the models, go the the model repository of the model of interest and click the `Files and versions` tab, and download the model and tokenizer files. For  programmatic downloading, if you have `huggingface_hub`
+installed, you can also run:
+
+```
+huggingface-cli download google/gemma-7b-it-pytorch
+``` 
+
 Note that you can choose between the 2B, 7B, 7B int8 quantized variants.
 
 ```


### PR DESCRIPTION
Hi there :hugs: In collaboration with Google, we added the gemma.pytorch files to the Hugging Face Hub. This PR adds instructions to manually or programmatically download the models.