### PR TITLE
Gemma fixes - gelu

### DIFF
--- a/gemma/model.py
+++ b/gemma/model.py
@@ -194,7 +194,7 @@ class GemmaMLP(nn.Module):
 
     def forward(self, x):
         gate = self.gate_proj(x)
-        gate = F.gelu(gate)
+        gate = F.gelu(gate, approximate="tanh")
         up = self.up_proj(x)
         fuse = gate * up
         outputs = self.down_proj(fuse)


### PR DESCRIPTION
Just a few more Gemma fixes :) Currently checking for more as well!
Related PR: https://github.com/huggingface/transformers/pull/29285, which showed RoPE must be done in float32 and not float16, causing positional encodings to lose accuracy.

1. Activation function according to https://twitter.com/danielhanchen/status/1763613620909580505 (waiting for confirmation) should be approximate gelu and not exact gelu. Ie gelu should actually be gelu_pytorch_tanh which calls PytorchGELUTanh and that calls nn.functional.gelu(input, approximate="tanh"). gelu calls nn.functional.gelu(input, approximate="none")

Will scour for more and will add them here :) (Hopefully the gelu issue is the only one!!)