### PR TITLE
Document the existence of 99 unused tokens in the tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ docker run -t --rm --privileged \
     # add `--quant` for the int8 quantized model.
 ```
 
+### Tokenizer Notes
+
+99 unused tokens are reserved in the pretrained tokenizer model to assist with more efficient training/fine-tuning. Unused tokens are in the string format of `<unused[0-98]>` with token id range of `[7-105]`. 
+
+```
+"<unused0>": 7,
+"<unused1>": 8,
+"<unused2>": 9,
+...
+"<unused98>": 105,
+```
+
 ## Disclaimer
 
 This is not an officially supported Google product.


### PR DESCRIPTION
Add notes to assist model developers to more efficiently  train/fine-tune Gemma by re-using the reserved tokens rather than attempting to resizing the BPE based tokenizer. 

ref: https://github.com/google/gemma_pytorch/issues/12

@pengchongjin  @suryabhupa