### PR TITLE
Memory saving loading weight for non-quant models

### DIFF
--- a/gemma/model.py
+++ b/gemma/model.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Inference-only Gemma model implementation."""
 
+import re
 import torch
 from torch import nn
 import torch.nn.functional as F

--- a/gemma/model.py
+++ b/gemma/model.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Inference-only Gemma model implementation."""
 
-import re
 import torch
 from torch import nn
 import torch.nn.functional as F

--- a/gemma/model.py
+++ b/gemma/model.py
@@ -558,9 +558,13 @@ class GemmaForCausalLM(nn.Module):
         return results[0] if is_str_prompt else results
 
     def load_weights(self, model_path: str):
-        self.load_state_dict(
-            torch.load(
-                model_path, mmap=True, weights_only=True,
-            )['model_state_dict'],
-            strict=False,
-        )
+        if self.config.quant:
+            self.load_state_dict(
+                torch.load(model_path, mmap=True, weights_only=True)['model_state_dict'],
+                strict=False
+            )
+        else:
+            self.load_state_dict(
+                torch.load(model_path, weights_only=True)['model_state_dict'],
+                strict=False, assign=True
+            )

--- a/gemma/model_xla.py
+++ b/gemma/model_xla.py
@@ -18,7 +18,7 @@ import re
 import torch
 from torch import nn
 import torch.nn.functional as F
-from typing import Any, List, Optional, Sequence, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from gemma import config as gemma_config
 from gemma.xla_model_parallel import (

--- a/gemma/model_xla.py
+++ b/gemma/model_xla.py
@@ -18,7 +18,7 @@ import re
 import torch
 from torch import nn
 import torch.nn.functional as F
-from typing import List, Optional, Tuple, Union
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 from gemma import config as gemma_config
 from gemma.xla_model_parallel import (


### PR DESCRIPTION
Trying to fix #51 
And this also increase the speed of loading weights. (in my computer, about 1min vs 2min)
Tested on `1.1-7b-it` and `7b-it` model.

but:
1. This method is not suitable for the int8 data type, so the original loading method is still used when using the `quant` model.
2. The new loading method will automatically reset the `requires_grad` of `nn.Parameter` in `Linear` and `Embedding` to `True` after the loading is completed. (I don't know why some nn.Parameters in model.py have `requires_grad` as False and others as default True) But I think, this shouldn't affect since `forward` function of `GemmaForCausalLM` has `@torch.no_grad()`.