### PR TITLE
Add required world_size and rank to GemmaDecodeLayer init

### DIFF
--- a/gemma/model_xla.py
+++ b/gemma/model_xla.py
@@ -527,7 +527,7 @@ class GemmaModel(nn.Module):
         self.layers = nn.ModuleList()
         for i in range(config.num_hidden_layers):
             if config.architecture == gemma_config.Architecture.GEMMA_1:
-                self.layers.append(GemmaDecoderLayer(config))
+                self.layers.append(GemmaDecoderLayer(config, world_size, rank))
             elif config.architecture == gemma_config.Architecture.GEMMA_2:
                 attn_type = (
                     config.attn_types[i]


### PR DESCRIPTION
fix #75

Just passing required arguments to the GemmaDecodeLayer \_\_init\_\_ in model_xla.