### PR TITLE
Set Gemma 3 4B max_position_embeddings to 128K

### DIFF
--- a/gemma/config.py
+++ b/gemma/config.py
@@ -233,6 +233,7 @@ def get_config_for_4b(dtype: str) -> GemmaConfig:
           AttentionType.GLOBAL: 1_000_000,
       },
       vocab_size=262_144,
+      max_position_embeddings=131_072,
       tokenizer='tokenizer/gemma3_cleaned_262144_v2.spiece.model',
       use_qk_norm=True,
       vision_config=siglip_vision_config.get_siglip_vision_model_config(),


### PR DESCRIPTION
`max_position_embeddings` is missing from the Gemma 3 4B config. It defaults to `8192` and the model will error if you pass more than `2*8192` tokens.

This PR sets `max_position_embeddings` to `131072` (`128*1024`) to match the 128K context length stated in the paper.

Note: In the [Kaggle](https://www.kaggle.com/models/google/gemma-3/pyTorch) checkpoints for `gemma-3-4b-it` and `gemma-3-4b-pt`, the `local_freqs_cis` and `global_freqs_cis` tensors currently have shape `(16384, 128)`. The checkpoints will need to be updated, otherwise `load_state_dict` will fail due to the shape mismatch.